### PR TITLE
fix(roll-handler): use core renderItem for sheet

### DIFF
--- a/scripts/roll-handler.js
+++ b/scripts/roll-handler.js
@@ -21,7 +21,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
       const renderable = ['item']
 
       if (renderable.includes(actionTypeId) && this.isRenderItem() && !isMultiToken) {
-        return this.doRenderItem(this.actor, actionId)
+        return this.renderItem(this.actor, actionId)
       }
 
       const knownCharacters = ['character', 'creature']


### PR DESCRIPTION
Use renderItem instead of doRenderItem to fix compatibility with current Token Action HUD Core.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal method handling for item rendering to improve code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->