### PR TITLE
fix(roll-handler): pass speaker token for checks

### DIFF
--- a/scripts/roll-handler.js
+++ b/scripts/roll-handler.js
@@ -141,7 +141,12 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
           return
         }
 
-        actor.rollCheck(checkValue, token.document)
+        if (token?.document) {
+          actor.rollCheck(checkValue, { speaker: { token: token.document } })
+        } else {
+          console.warn(`Token document missing for check roll: ${checkValue}`)
+          actor.rollCheck(checkValue)
+        }
       } catch (error) {
         ui.notifications.error(`Error rolling check: ${error.message}`)
       }


### PR DESCRIPTION
Properly pass token document for roll checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved roll attribution by adding token awareness to the roll system. Rolls are now properly associated with their originating tokens when available, with graceful fallback handling for edge cases where token information may be unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->